### PR TITLE
#151 ps がダメ/空なら /proc にフォールバックする処理を追加（Linux想定）

### DIFF
--- a/bin/dns_select.sh
+++ b/bin/dns_select.sh
@@ -97,7 +97,12 @@ event_lock() {
 
         else
             # pid は生きている → 本当に同一イベントか確認
-            args=$(ps -p "$old_pid" -o args= 2>/dev/null)
+            args=$(ps -p "$old_pid" -o args= 2>/dev/null || true)
+
+            # ps がダメ/空なら /proc にフォールバック（Linux想定）
+            if [ -z "$args" ] && [ -r "/proc/$old_pid/cmdline" ]; then
+                args=$(tr '\0' ' ' < "/proc/$old_pid/cmdline" 2>/dev/null || true)
+            fi
 
             case "$args" in
                 *dns_select.sh*"$Mode"*)


### PR DESCRIPTION
Issue #151

event_lock にて、ps -o args= が失敗または空の場合に
/proc/<pid>/cmdline へフォールバックする処理を追加しました。

- WSL(Ubuntu) にて動作確認
- ps 成功 / ps 失敗 → /proc / 照合不能 → 上書き続行 の各パターンを確認済み
- 既存の強化PID方式の挙動は変更なし