### PR TITLE
#155 install.sh SELinux対応 + systemd配置見直し（v2.0準備）

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,30 +2,45 @@
 #
 # update ddns uninstall.sh
 #
-# dipper 
+# dipper uninstall script
 
 SERVICE_NAME="dipper.service"
-User_servce="/etc/systemd/system/$SERVICE_NAME"
+SERVICE_FILE="/etc/systemd/system/$SERVICE_NAME"
 
-if [ -e ${User_servce} ]; then
-    # サービスの状態を確認
-    status=$(systemctl is-active "$SERVICE_NAME")
-    # 状態に応じて処理を分岐
+# -----------------------------
+# sudo を先に確保
+# -----------------------------
+sudo -v || exit 1
+
+# -----------------------------
+# systemd service 停止・無効化
+# -----------------------------
+if [ -f "$SERVICE_FILE" ]; then
+    status=$(systemctl is-active "$SERVICE_NAME" 2>/dev/null || true)
     if [ "$status" = "active" ]; then
         sudo systemctl stop "$SERVICE_NAME"
     fi
 
-    # サービスの有効化状態を確認
-    enabled=$(systemctl is-enabled "$SERVICE_NAME")
-    # 有効化状態に応じて処理を分岐
+    enabled=$(systemctl is-enabled "$SERVICE_NAME" 2>/dev/null || true)
     if [ "$enabled" = "enabled" ]; then
         sudo systemctl disable "$SERVICE_NAME"
     fi
 
-    if [ -e ${User_servce} ]; then
-        sudo rm -f /etc/systemd/system/dipper.service
-    fi
+    # service ファイル削除
+    sudo rm -f "$SERVICE_FILE"
+
     sudo systemctl daemon-reload
+else
+    echo "service file not found: $SERVICE_FILE"
 fi
 
-sudo rm -rf /usr/local/dipper
+# -----------------------------
+# dipper 本体削除
+# -----------------------------
+if [ -d /usr/local/dipper ]; then
+    sudo rm -rf /usr/local/dipper
+else
+    echo "/usr/local/dipper not found"
+fi
+
+echo "dipper uninstall done."


### PR DESCRIPTION
## 変更概要
- install.sh を SELinux を考慮した方式に修正（cp -a 廃止 / restorecon 条件付き実行）
- systemd service を /etc/systemd/system に配置する運用へ整理
- uninstall.sh を install と対称になるよう整理
- README を現行設計に合わせて更新

## 動作確認
- AlmaLinux 10（SELinux 有効）で install.sh → dipper.service 起動まで確認（SELinux エラーなし）
- uninstall.sh 実行確認

Refs: #155